### PR TITLE
Update the new master from develop

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+cad_to_shapely==0.3
+matplotlib==3.4.3
+more_itertools==8.12.0
+numpy==1.21.2
+pytest==7.1.1
+pytest_check==1.0.5
+rhino_shapley_interop==0.0.4
+scipy==1.7.1
+Shapely==1.8.1.post1
+sphinx_gallery==0.10.1
+triangle==20220202


### PR DESCRIPTION
Bisogna farlo perché su master manca il __init__.pyche invece abbiamo messo in develop, e se si scaricano di nuovo le repo, in default vanno tutte su master e non va più. (almeno credo sia per quello).